### PR TITLE
Watchdog Timer implementation

### DIFF
--- a/Avionics/Firmware/include/IMU_Control.h
+++ b/Avionics/Firmware/include/IMU_Control.h
@@ -7,6 +7,8 @@
 #define GYRO_CONFIG_1 0x01
 #define ACCEL_CONFIG 0x14
 
+#define TIMEOUT_MS 3000
+
 //Initialize IMU (ICM20948)
 extern Adafruit_ICM20948 imu;
 
@@ -20,6 +22,9 @@ extern float accel_z_offset;
 void initIMU();
 void configIMU();
 void calibrateGyroAccel();
+
+bool getImuDataWithTimeout(sensors_event_t *accel, sensors_event_t *gyro, sensors_event_t *mag, sensors_event_t *temp);
+void resetI2CBus();
 
 // Set low noise modes for both gyroscope and accelerometer
 void setLowNoiseMode();

--- a/Avionics/Firmware/src/IMU_Control.cpp
+++ b/Avionics/Firmware/src/IMU_Control.cpp
@@ -79,3 +79,24 @@ void setLowNoiseMode(){
   imu.writeExternalRegister(ICM_ADDR, GYRO_CONFIG_1, 0x01);
   imu.writeExternalRegister(ICM_ADDR, ACCEL_CONFIG, 0x01);
 }
+
+void resetI2CBus() {
+  Wire.end();
+  Wire.begin();
+  Serial.println("I2C bus reset");
+}
+
+bool getImuDataWithTimeout(sensors_event_t *accel, sensors_event_t *gyro, sensors_event_t *mag, sensors_event_t *temp){
+  uint32_t _startTime = millis();
+
+  while (!imu.getEvent(accel, gyro, mag, temp)) {
+    if (millis() - _startTime > TIMEOUT_MS) {
+      Serial.println("Sensor data read timeout!");
+      resetI2CBus();
+      return false;
+    }
+    delay(10);  // Small delay to avoid blocking the loop too tightly
+  }
+
+  return true;
+}

--- a/Avionics/Firmware/src/flightdata.cpp
+++ b/Avionics/Firmware/src/flightdata.cpp
@@ -43,7 +43,7 @@ void FlightData::update_values() {
   time = millis() - startTime;
 
   sensors_event_t accel, gyro, mag, temp;
-  imu.getEvent(&accel, &gyro, &mag, &temp);
+  getImuDataWithTimeout(&accel, &gyro, &mag, &temp); //With watchdog timer
 
   accel.acceleration.x -= accel_x_offset;
   accel.acceleration.y -= accel_y_offset;

--- a/Avionics/Firmware/src/main.cpp
+++ b/Avionics/Firmware/src/main.cpp
@@ -24,7 +24,8 @@ bool pmosState = true;
 bool nmosState = false;
 
 void setup() {
-  Wire.begin(21, 22); // SDA on GPIO 21, SCL on GPIO 22   
+  Wire.begin(21, 22); // SDA on GPIO 21, SCL on GPIO 22 
+
   Serial.begin(115200);
   while(!Serial) {}
 
@@ -77,7 +78,7 @@ void loop() {
   remoteControl(beginFlight);
 
   yield();
-}
+;}
 
 // Flip PMOS and NMOS states for ignition control, begin gimbal control and data logging
 void beginFlight() {


### PR DESCRIPTION
Implemented watchdog timer for I2C communication between ESP32 and IMU. Tested the system to see if data was being successfully read. Could not test the watchdog timer itself. 
Identified a bug where the data collected was not being saved as the file wasn't open. Could not identify the cause. Will be creating a ticket about this bug and will attempt to resolve the issue shortly in another pull request.