### PR TITLE
Fixed issue 19

### DIFF
--- a/Avionics/Firmware/src/flightdata.cpp
+++ b/Avionics/Firmware/src/flightdata.cpp
@@ -41,23 +41,30 @@ float FlightData::getTemp() const {
 */
 void FlightData::update_values() {
   time = millis() - startTime;
-
+  
   sensors_event_t accel, gyro, mag, temp;
   imu.getEvent(&accel, &gyro, &mag, &temp);
 
-  accel.acceleration.x -= accel_x_offset;
-  accel.acceleration.y -= accel_y_offset;
-  accel.acceleration.z -= accel_z_offset;
-
-  this->acceleration = accel.acceleration;
-
-  gyro.gyro.x -= gyro_x_offset;
-  gyro.gyro.y -= gyro_y_offset;
-  gyro.gyro.z -= gyro_z_offset;
-  
-  this->gyroscope = gyro.gyro;
   this->magnetic = mag.magnetic;
   this->temperature = temp.temperature;
+
+  // Account for IMU position within rocket:
+  if (rotation_axis == 'X') {
+    this->acceleration.x = accel.acceleration.x - accel_x_offset;
+    this->acceleration.y = accel.acceleration.z - accel_z_offset;
+    this->acceleration.z = accel.acceleration.y - accel_y_offset;
+    this->gyroscope.x = gyro.gyro.x - gyro_x_offset;
+    this->gyroscope.y = gyro.gyro.z - gyro_z_offset;
+    this->gyroscope.z = gyro.gyro.y - gyro_y_offset;
+  } 
+  else if (rotation_axis == 'Y') {
+    this->acceleration.x = accel.acceleration.z - accel_z_offset;
+    this->acceleration.y = accel.acceleration.y - accel_y_offset;
+    this->acceleration.z = accel.acceleration.x - accel_x_offset;
+    this->gyroscope.x = gyro.gyro.z - gyro_z_offset;
+    this->gyroscope.y = gyro.gyro.y - gyro_y_offset;
+    this->gyroscope.z = gyro.gyro.x - gyro_x_offset;
+  } 
 }
 
 void FlightData::print_values() {


### PR DESCRIPTION
Axes are now swapped (it must be known whether the IMU was rotated about its x-axis or y-axis when placed in the rocket). For PID, use the values in the currentData object as the true x, y, z values.